### PR TITLE
Accept variables (NameExpr) in loguru calls

### DIFF
--- a/loguru_mypy/__init__.py
+++ b/loguru_mypy/__init__.py
@@ -52,7 +52,10 @@ NAME_TO_BOOL = {
 }  # type: te.Final
 
 
-def _check_str_format_call(log_msg_expr: StrExpr, ctx: MethodContext) -> None:
+def _check_str_format_call(
+    log_msg_expr: t.Union[StrExpr, NameExpr],
+    ctx: MethodContext,
+) -> None:
     """ Taps into mypy to typecheck something like this:
 
         ```py
@@ -98,7 +101,7 @@ def _loguru_logger_call_handler(
     log_msg_expr = ctx.args[0][0]
     logger_opts = loggers.get(ctx.type) or DEFAULT_OPTS
 
-    if isinstance(log_msg_expr, StrExpr):
+    if isinstance(log_msg_expr, (StrExpr, NameExpr)):
         _check_str_format_call(log_msg_expr, ctx)
     elif isinstance(log_msg_expr, (IntExpr, FloatExpr)):
         # nothing to be done, this is valid log
@@ -107,7 +110,7 @@ def _loguru_logger_call_handler(
     else:
         raise TypeError(f'No idea (yet) how to handle {type(log_msg_expr)}')
 
-    if logger_opts.lazy:
+    if logger_opts.lazy and isinstance(log_msg_expr, StrExpr):
         # collect call args/kwargs
         # due to funky structure mypy offers here, it's easier
         # to beg for forgiveness here

--- a/typesafety/test_issue_49.yml
+++ b/typesafety/test_issue_49.yml
@@ -7,7 +7,7 @@
     logger.debug(123.3)
     logger.trace(1)
     logger.error(.3)
-- case: variables
+- case: variables_str_no_args
   parametrized:
     - level: info
     - level: debug

--- a/typesafety/test_issue_49.yml
+++ b/typesafety/test_issue_49.yml
@@ -7,3 +7,51 @@
     logger.debug(123.3)
     logger.trace(1)
     logger.error(.3)
+- case: variables
+  parametrized:
+    - level: info
+    - level: debug
+    - level: warning
+    - level: error
+    - level: trace
+    - level: exception
+  main: |
+    from loguru import logger
+
+    foo = "bar"
+    logger.{{ level }}(foo)
+- case: variables__type-checked__wrong
+  main: |
+    from loguru import logger
+    from typing_extensions import Final
+
+    foo: Final = "bar"
+    logger.info(foo, 1)
+  out: |
+    main:5: error: Not all arguments converted during string formatting  [str-format]
+- case: variables__type-checked__correct
+  main: |
+    from loguru import logger
+    from typing_extensions import Final
+
+    foo: Final = "bar {}"
+    logger.info(foo, 1)
+- case: variables__mypy_cant_tell
+  main: |
+    from loguru import logger
+    from typing_extensions import Final
+
+    foo = "bar"
+    logger.info(foo, 1)  # This is wrong but mypy is at a loss
+- case: variables__type-checked__non-string
+  main: |
+    from loguru import logger
+    from typing_extensions import Final
+
+    foo: Final = 123.4
+    logger.info(foo, 1)
+  out: |
+    main:5: error: No overload variant of "info" of "Logger" matches argument types "float", "int"  [call-overload]
+    main:5: note:     <1 more non-matching overload not shown>
+    main:5: note:     def info(__self, str, *args: Any, **kwargs: Any) -> None
+    main:5: note: Possible overload variant:


### PR DESCRIPTION
Fixes example 3 of #49

Note that mypy _cannot_ type-check a format expression if it is not Final.
E.g.:

```python
from loguru import logger
from typing import Final

foo: Final = "bar"
logger.info(foo, 1)  # error: Not all arguments converted during string formatting
foo = "bar"
logger.info(foo, 1)  # no error (and will fail at runtime)
```

This is a limitation with mypy and I don't think we can do much about it