### PR TITLE
Accept Any Single Argument

### DIFF
--- a/loguru_mypy/__init__.py
+++ b/loguru_mypy/__init__.py
@@ -108,7 +108,11 @@ def _loguru_logger_call_handler(
         # and callee is not expected to provide anything useful over here
         return ctx.default_return_type
     else:
-        raise TypeError(f'No idea (yet) how to handle {type(log_msg_expr)}')
+        ctx.api.msg.note(
+            f'The loguru plugin cannot handle {type(log_msg_expr)} (yet)',
+            context=log_msg_expr,
+        )
+        return ctx.default_return_type
 
     if logger_opts.lazy and isinstance(log_msg_expr, StrExpr):
         # collect call args/kwargs

--- a/typesafety/test_issue_49.yml
+++ b/typesafety/test_issue_49.yml
@@ -7,6 +7,13 @@
     logger.debug(123.3)
     logger.trace(1)
     logger.error(.3)
+- case: containers
+  main: |
+    from loguru import logger
+
+    logger.info(["096", 682, 173, 3125])
+    logger.debug({"093": "Red Sea Object", 55: ["unknown"], 106: "The Old Man"})
+    logger.debug({914, "taboo", 3008, 999})
 - case: variables_str_no_args
   parametrized:
     - level: info


### PR DESCRIPTION
Raising an exception turns into an internal error for mypy which is not very user-friendly and is not visible in my IDE.
Also and more importantly an error cannot be ignored via `# type: ignore` which is sure to break any CI pipeline.
By sending a note instead, the user is warned and is free to ignore the error for now and maybe contribute a fix later ;)